### PR TITLE
Change default opencensus server port

### DIFF
--- a/src/ConsoleHost/LocalForwarder.config
+++ b/src/ConsoleHost/LocalForwarder.config
@@ -23,7 +23,7 @@ This is a configuration file for LocalForwarder.
     -->
     <OpenCensusInput Enabled="true">
       <Host>0.0.0.0</Host>
-      <Port>50002</Port>
+      <Port>55678</Port>
     </OpenCensusInput>
 
   </Inputs>

--- a/src/LibraryTest/Library/ConfigurationTests.cs
+++ b/src/LibraryTest/Library/ConfigurationTests.cs
@@ -35,7 +35,7 @@ namespace Microsoft.LocalForwarder.LibraryTest.Library
 
             Assert.AreEqual(true, config.OpenCensusInput_Enabled);
             Assert.AreEqual("0.0.0.0", config.OpenCensusInput_Host);
-            Assert.AreEqual(50002, config.OpenCensusInput_Port);
+            Assert.AreEqual(55678, config.OpenCensusInput_Port);
 
             Assert.AreEqual("[SPECIFY INSTRUMENTATION KEY HERE]", config.OpenCensusToApplicationInsights_InstrumentationKey);
         }


### PR DESCRIPTION
https://github.com/census-instrumentation/opencensus-proto/pull/97:

Default agent port is set to 55678.