### PR TITLE
LF should reply only when config changes occur

### DIFF
--- a/src/Library/Inputs/GrpcInput/GrpcInput.cs
+++ b/src/Library/Inputs/GrpcInput/GrpcInput.cs
@@ -176,7 +176,12 @@
 
                     try
                     {
-                        await responseStream.WriteAsync(this.onConfigReceived(configRequest, context)).ConfigureAwait(false);
+                        var configResponse = this.onConfigReceived(configRequest, context);
+                        if (configRequest.Config == null || !configRequest.Config.Equals(configResponse.Config))
+                        {
+                            await responseStream.WriteAsync(configResponse)
+                                .ConfigureAwait(false);
+                        }
 
                         Interlocked.Increment(ref this.stats.ConfigsReceived);
                     }


### PR DESCRIPTION
Exporter keeps sending config until LF replies with config. It leads to endless loop between exporter/agent.

To prevent it, dor now, we'll not write it to the response stream.  In future, we may consider holding response and push config when it changes back to the exporter.