### PR TITLE
Internal SDK version format changes

### DIFF
--- a/src/Library/AiTelemetryConverter.cs
+++ b/src/Library/AiTelemetryConverter.cs
@@ -284,7 +284,7 @@
                 }
                 else if (string.Equals(tag.Key, AiTelemetryConverter.TagKeys.InternalSdkVersion, StringComparison.InvariantCultureIgnoreCase))
                 {
-                    telemetry.Context.GetInternalContext().SdkVersion = tag.Value;
+                    telemetry.Context.GetInternalContext().SdkVersion = string.Concat("lf_", tag.Value);
                 }
                 else if (string.Equals(tag.Key, AiTelemetryConverter.TagKeys.LocationIp, StringComparison.InvariantCultureIgnoreCase))
                 {

--- a/src/Library/OpenCensusTelemetryConverter.cs
+++ b/src/Library/OpenCensusTelemetryConverter.cs
@@ -43,26 +43,28 @@
         private const string LinkSpanIdPropertyName = "spanId";
         private const string LinkTraceIdPropertyName = "traceId";
         private const string LinkTypePropertyName = "type";
-        private const string SdkVersionPrefix = "oclf"; 
         private static readonly string AssemblyVersion = GetAssemblyVersionString();
 
         private const string PeerPropertyKey = "peer";
         private const string OpenCensusExporterVersionPropertyKey = "oc_exporter_version";
-        private const string OpenCensusCoreLibraryVersionPropertyKey = "oc_library_version";
+        private const string LocalForwarderVersion = "lf_version";
         private const string StartTimestampPropertyKey = "process_start_ts";
 
         private static readonly uint[] Lookup32 = CreateLookup32();
 
+        private static readonly Dictionary<LibraryInfo.Types.Language, string> FriendlyLanguageNames =
+            CacheLanguageNames();
+
         public static void TrackNodeEvent(this TelemetryClient telemetryClient, Node peerInfo, string eventName, string peer, string ikey)
         {
-            EventTelemetry nodeEvent = new EventTelemetry($"{eventName}.node");
+            EventTelemetry nodeEvent = new EventTelemetry(string.Concat(eventName, ".node"));
             SetPeerInfo(nodeEvent, peerInfo);
 
             nodeEvent.Properties[PeerPropertyKey] = peer;
             if (peerInfo.LibraryInfo != null)
             {
                 nodeEvent.Properties[OpenCensusExporterVersionPropertyKey] = peerInfo.LibraryInfo.ExporterVersion;
-                nodeEvent.Properties[OpenCensusCoreLibraryVersionPropertyKey] = peerInfo.LibraryInfo.CoreLibraryVersion;
+                nodeEvent.Properties[LocalForwarderVersion] = AssemblyVersion;
             }
 
             if (peerInfo.Identifier?.StartTimestamp != null )
@@ -575,7 +577,7 @@
         private static void SetPeerInfo(ITelemetry telemetry, Node peerInfo)
         {
             string libLanguage = null;
-
+            string ocLibVersion = null;
             if (peerInfo != null)
             {
                 if (peerInfo.ServiceInfo != null)
@@ -590,12 +592,23 @@
 
                 if (peerInfo.LibraryInfo != null)
                 {
-                    libLanguage = ((int) peerInfo.LibraryInfo.Language).ToString();
+                    libLanguage = FriendlyLanguageNames[peerInfo.LibraryInfo.Language];
+                    ocLibVersion = peerInfo.LibraryInfo.CoreLibraryVersion;
                 }
             }
 
+            if (string.IsNullOrEmpty(libLanguage))
+            {
+                libLanguage = FriendlyLanguageNames[LibraryInfo.Types.Language.Unspecified];
+            }
+
+            if (string.IsNullOrEmpty(ocLibVersion))
+            {
+                ocLibVersion = "0.0.0";
+            }
+
             telemetry.Context.GetInternalContext().SdkVersion =
-                string.Concat(SdkVersionPrefix, libLanguage ?? "0", ':', AssemblyVersion);
+                string.Concat("lf_", libLanguage, "_oc:", ocLibVersion);
         }
 
         internal static string GetAssemblyVersionString()
@@ -628,6 +641,12 @@
                     }
                 }
             }
+        }
+
+        private static Dictionary<LibraryInfo.Types.Language, string> CacheLanguageNames()
+        {
+            var values = (LibraryInfo.Types.Language[])Enum.GetValues(typeof(LibraryInfo.Types.Language));
+            return values.ToDictionary(v => v, v => v.ToString().ToLower());
         }
     }
 }

--- a/src/LibraryTest/Library/AiTelemetryConverterTests.cs
+++ b/src/LibraryTest/Library/AiTelemetryConverterTests.cs
@@ -1,3 +1,5 @@
+using Microsoft.ApplicationInsights.Extensibility.Implementation;
+
 namespace Microsoft.LocalForwarder.LibraryTest.Library
 {
     using Microsoft.ApplicationInsights.DataContracts;
@@ -29,6 +31,7 @@ namespace Microsoft.LocalForwarder.LibraryTest.Library
             };
 
             telemetry.Tags.Add(new ContextTagKeys().SessionId, "sessionId");
+            telemetry.Tags.Add("ai.internal.sdkVersion", "java:2.1.2");
 
             telemetry.Event.Properties.Add("prop1", "propValue1");
             telemetry.Event.Measurements.Add("measurement1", 105);
@@ -48,6 +51,7 @@ namespace Microsoft.LocalForwarder.LibraryTest.Library
             Assert.AreEqual(timestamp, result.Timestamp);
             Assert.AreEqual("ikey", result.Context.InstrumentationKey);
             Assert.AreEqual("sessionId", result.Context.Session.Id);
+            Assert.AreEqual("lf_java:2.1.2", result.Context.GetInternalContext().SdkVersion);
 
             // sampling fields
             Assert.AreEqual(25, (result as ISupportSampling).SamplingPercentage);
@@ -71,6 +75,7 @@ namespace Microsoft.LocalForwarder.LibraryTest.Library
             };
 
             telemetry.Tags.Add(new ContextTagKeys().SessionId, "sessionId");
+            telemetry.Tags.Add("ai.internal.sdkVersion", "java:2.1.2");
 
             telemetry.Message.Properties.Add("prop1", "propValue1");
             
@@ -88,6 +93,7 @@ namespace Microsoft.LocalForwarder.LibraryTest.Library
             Assert.AreEqual(timestamp, result.Timestamp);
             Assert.AreEqual("ikey", result.Context.InstrumentationKey);
             Assert.AreEqual("sessionId", result.Context.Session.Id);
+            Assert.AreEqual("lf_java:2.1.2", result.Context.GetInternalContext().SdkVersion);
 
             // sampling fields
             Assert.AreEqual(25, (result as ISupportSampling).SamplingPercentage);
@@ -111,6 +117,7 @@ namespace Microsoft.LocalForwarder.LibraryTest.Library
             };
 
             telemetry.Tags.Add(new ContextTagKeys().SessionId, "sessionId");
+            telemetry.Tags.Add("ai.internal.sdkVersion", "java:2.1.2");
 
             telemetry.Metric.Metrics.Add(new DataPoint() { Ns = "ns1", Name = "Metric1", Kind = DataPointType.Measurement, Value = 11, Count = new Google.Protobuf.WellKnownTypes.Int32Value() { Value = 1 } });
             
@@ -137,6 +144,7 @@ namespace Microsoft.LocalForwarder.LibraryTest.Library
             Assert.AreEqual(timestamp, result.Timestamp);
             Assert.AreEqual("ikey", result.Context.InstrumentationKey);
             Assert.AreEqual("sessionId", result.Context.Session.Id);
+            Assert.AreEqual("lf_java:2.1.2", result.Context.GetInternalContext().SdkVersion);
         }
 
         [TestMethod]
@@ -157,6 +165,7 @@ namespace Microsoft.LocalForwarder.LibraryTest.Library
             };
 
             telemetry.Tags.Add(new ContextTagKeys().SessionId, "sessionId");
+            telemetry.Tags.Add("ai.internal.sdkVersion", "java:2.1.2");
 
             telemetry.Metric.Metrics.Add(new DataPoint()
             {
@@ -193,6 +202,7 @@ namespace Microsoft.LocalForwarder.LibraryTest.Library
             Assert.AreEqual(timestamp, result.Timestamp);
             Assert.AreEqual("ikey", result.Context.InstrumentationKey);
             Assert.AreEqual("sessionId", result.Context.Session.Id);
+            Assert.AreEqual("lf_java:2.1.2", result.Context.GetInternalContext().SdkVersion);
         }
 
         [TestMethod]
@@ -218,6 +228,7 @@ namespace Microsoft.LocalForwarder.LibraryTest.Library
             };
 
             telemetry.Tags.Add(new ContextTagKeys().SessionId, "sessionId");
+            telemetry.Tags.Add("ai.internal.sdkVersion", "java:2.1.2");
 
             telemetry.Exception.Exceptions.Add(new ExceptionDetails() { Id = 12, OuterId = 13, TypeName = "TerribleException1", Message = "Oh wow look what happened 1", HasFullStack = new Google.Protobuf.WellKnownTypes.BoolValue() { Value = true }, Stack = "Terrible stack 1" });
             telemetry.Exception.Exceptions[0].ParsedStack.Add(new LocalForwarder.Library.Inputs.Contracts.StackFrame() { Level = 4, Method = "Method1", Assembly = "Assm1", FileName = "File1", Line = 145 });
@@ -308,6 +319,7 @@ namespace Microsoft.LocalForwarder.LibraryTest.Library
             Assert.AreEqual(timestamp, result.Timestamp);
             Assert.AreEqual("ikey", result.Context.InstrumentationKey);
             Assert.AreEqual("sessionId", result.Context.Session.Id);
+            Assert.AreEqual("lf_java:2.1.2", result.Context.GetInternalContext().SdkVersion);
 
             // sampling fields
             Assert.AreEqual(25, (result as ISupportSampling).SamplingPercentage);
@@ -331,6 +343,7 @@ namespace Microsoft.LocalForwarder.LibraryTest.Library
             };
 
             telemetry.Tags.Add(new ContextTagKeys().SessionId, "sessionId");
+            telemetry.Tags.Add("ai.internal.sdkVersion", "java:2.1.2");
 
             telemetry.Dependency.Properties.Add("prop1", "propValue1");
             telemetry.Dependency.Measurements.Add("measurement1", 105);
@@ -358,6 +371,7 @@ namespace Microsoft.LocalForwarder.LibraryTest.Library
             Assert.AreEqual(timestamp, result.Timestamp);
             Assert.AreEqual("ikey", result.Context.InstrumentationKey);
             Assert.AreEqual("sessionId", result.Context.Session.Id);
+            Assert.AreEqual("lf_java:2.1.2", result.Context.GetInternalContext().SdkVersion);
 
             // sampling fields
             Assert.AreEqual(25, (result as ISupportSampling).SamplingPercentage);
@@ -381,6 +395,7 @@ namespace Microsoft.LocalForwarder.LibraryTest.Library
             };
 
             telemetry.Tags.Add(new ContextTagKeys().SessionId, "sessionId");
+            telemetry.Tags.Add("ai.internal.sdkVersion", "java:2.1.2");
 
             telemetry.Availability.Properties.Add("prop1", "propValue1");
             telemetry.Availability.Measurements.Add("measurement1", 105);
@@ -406,6 +421,7 @@ namespace Microsoft.LocalForwarder.LibraryTest.Library
             Assert.AreEqual(timestamp, result.Timestamp);
             Assert.AreEqual("ikey", result.Context.InstrumentationKey);
             Assert.AreEqual("sessionId", result.Context.Session.Id);
+            Assert.AreEqual("lf_java:2.1.2", result.Context.GetInternalContext().SdkVersion);
         }
 
         [TestMethod]
@@ -426,6 +442,7 @@ namespace Microsoft.LocalForwarder.LibraryTest.Library
             };
 
             telemetry.Tags.Add(new ContextTagKeys().SessionId, "sessionId");
+            telemetry.Tags.Add("ai.internal.sdkVersion", "java:2.1.2");
 
             telemetry.PageView.Event.Properties.Add("prop1", "propValue1");
             telemetry.PageView.Event.Measurements.Add("measurement1", 105);
@@ -449,6 +466,7 @@ namespace Microsoft.LocalForwarder.LibraryTest.Library
             Assert.AreEqual(timestamp, result.Timestamp);
             Assert.AreEqual("ikey", result.Context.InstrumentationKey);
             Assert.AreEqual("sessionId", result.Context.Session.Id);
+            Assert.AreEqual("lf_java:2.1.2", result.Context.GetInternalContext().SdkVersion);
 
             // sampling fields
             Assert.AreEqual(25, (result as ISupportSampling).SamplingPercentage);
@@ -472,6 +490,7 @@ namespace Microsoft.LocalForwarder.LibraryTest.Library
             };
 
             telemetry.Tags.Add(new ContextTagKeys().SessionId, "sessionId");
+            telemetry.Tags.Add("ai.internal.sdkVersion", "java:2.1.2");
 
             telemetry.Request.Properties.Add("prop1", "propValue1");
             telemetry.Request.Measurements.Add("measurement1", 105);
@@ -497,6 +516,7 @@ namespace Microsoft.LocalForwarder.LibraryTest.Library
             Assert.AreEqual(timestamp, result.Timestamp);
             Assert.AreEqual("ikey", result.Context.InstrumentationKey);
             Assert.AreEqual("sessionId", result.Context.Session.Id);
+            Assert.AreEqual("lf_java:2.1.2", result.Context.GetInternalContext().SdkVersion);
 
             // sampling fields
             Assert.AreEqual(25, (result as ISupportSampling).SamplingPercentage);

--- a/src/LibraryTest/Library/OpenCensusTelemetryConverterTests.cs
+++ b/src/LibraryTest/Library/OpenCensusTelemetryConverterTests.cs
@@ -75,7 +75,7 @@ namespace Microsoft.LocalForwarder.LibraryTest.Library
             Assert.IsFalse(request.Success.HasValue);
             Assert.IsTrue(string.IsNullOrEmpty(request.ResponseCode));
 
-            Assert.AreEqual($"oclf0:{GetAssemblyVersionString()}", request.Context.GetInternalContext().SdkVersion);
+            Assert.AreEqual("lf_unspecified_oc:0.0.0", request.Context.GetInternalContext().SdkVersion);
         }
 
         [TestMethod]
@@ -100,7 +100,7 @@ namespace Microsoft.LocalForwarder.LibraryTest.Library
             Assert.AreEqual(2, request.Properties.Count);
             Assert.AreEqual("v1", request.Properties["k1"]);
             Assert.AreEqual("v2", request.Properties["k2"]);
-            Assert.AreEqual($"oclf0:{GetAssemblyVersionString()}", request.Context.GetInternalContext().SdkVersion);
+            Assert.AreEqual("lf_unspecified_oc:0.0.0", request.Context.GetInternalContext().SdkVersion);
         }
 
         [TestMethod]
@@ -230,7 +230,7 @@ namespace Microsoft.LocalForwarder.LibraryTest.Library
             Assert.IsTrue(string.IsNullOrEmpty(dependency.ResultCode));
             Assert.IsFalse(dependency.Success.HasValue);
 
-            Assert.AreEqual($"oclf0:{GetAssemblyVersionString()}", dependency.Context.GetInternalContext().SdkVersion);
+            Assert.AreEqual("lf_unspecified_oc:0.0.0", dependency.Context.GetInternalContext().SdkVersion);
 
             Assert.IsTrue(string.IsNullOrEmpty(dependency.Type));
         }
@@ -257,7 +257,7 @@ namespace Microsoft.LocalForwarder.LibraryTest.Library
             Assert.AreEqual(2, dependency.Properties.Count);
             Assert.AreEqual("v1", dependency.Properties["k1"]);
             Assert.AreEqual("v2", dependency.Properties["k2"]);
-            Assert.AreEqual($"oclf0:{GetAssemblyVersionString()}", dependency.Context.GetInternalContext().SdkVersion);
+            Assert.AreEqual("lf_unspecified_oc:0.0.0", dependency.Context.GetInternalContext().SdkVersion);
         }
 
         [TestMethod]
@@ -1709,11 +1709,11 @@ namespace Microsoft.LocalForwarder.LibraryTest.Library
             var evnt = this.sentItems.OfType<EventTelemetry>().Single();
             Assert.AreEqual("ikey1", evnt.Context.InstrumentationKey);
             Assert.AreEqual($"{eventName}.node", evnt.Name);
-            Assert.IsTrue(evnt.Context.GetInternalContext().SdkVersion.StartsWith($"oclf{(int)lang}"));
+            Assert.AreEqual($"lf_{lang.ToString().ToLower()}_oc:{version}", evnt.Context.GetInternalContext().SdkVersion);
             Assert.AreEqual(serviceName, evnt.Context.Cloud.RoleName);
             Assert.AreEqual($"{hostName}.{pid}", evnt.Context.Cloud.RoleInstance);
 
-            Assert.AreEqual(version, evnt.Properties["oc_library_version"]);
+            Assert.AreEqual(GetAssemblyVersionString(), evnt.Properties["lf_version"]);
             Assert.AreEqual(start.ToString("o"), evnt.Properties["process_start_ts"]);
             Assert.AreEqual(peer, evnt.Properties["peer"]);
 
@@ -1736,7 +1736,7 @@ namespace Microsoft.LocalForwarder.LibraryTest.Library
             var evnt = this.sentItems.OfType<EventTelemetry>().Single();
             Assert.AreEqual("ikey1", evnt.Context.InstrumentationKey);
             Assert.AreEqual($"{eventName}.node", evnt.Name);
-            Assert.IsTrue(evnt.Context.GetInternalContext().SdkVersion.StartsWith("oclf0"));
+            Assert.AreEqual("lf_unspecified_oc:0.0.0", evnt.Context.GetInternalContext().SdkVersion);
             Assert.IsNull(evnt.Context.Cloud.RoleName);
             Assert.AreEqual(peer, evnt.Properties["peer"]);
             Assert.AreEqual(1, evnt.Properties.Count);
@@ -1762,11 +1762,11 @@ namespace Microsoft.LocalForwarder.LibraryTest.Library
             var evnt = this.sentItems.OfType<EventTelemetry>().Single();
             Assert.AreEqual("ikey1", evnt.Context.InstrumentationKey);
             Assert.AreEqual($"{eventName}.node", evnt.Name);
-            Assert.IsTrue(evnt.Context.GetInternalContext().SdkVersion.StartsWith("oclf0"));
+            Assert.AreEqual("lf_unspecified_oc:2", evnt.Context.GetInternalContext().SdkVersion);
             Assert.IsNull(evnt.Context.Cloud.RoleName);
             Assert.AreEqual(peer, evnt.Properties["peer"]);
             Assert.AreEqual("1", evnt.Properties["oc_exporter_version"]);
-            Assert.AreEqual("2", evnt.Properties["oc_library_version"]);
+            Assert.AreEqual(GetAssemblyVersionString(), evnt.Properties["lf_version"]);
             Assert.AreEqual(3, evnt.Properties.Count);
 
             Assert.AreEqual(".1", evnt.Context.Cloud.RoleInstance);


### PR DESCRIPTION
OC data: lf_<lang>_oc:<oc lib version>. e.g. `lf_python_oc:0.1.6`

Ai Data: lf_<internalSdk version>. E,g, 'lf_java:2.1.2'