### PR TITLE
fix-python-app-import-ParseError

### DIFF
--- a/examples/opencensus/python-app/requirements.txt
+++ b/examples/opencensus/python-app/requirements.txt
@@ -1,3 +1,4 @@
 Django==1.11.7
 grpcio==1.8.3
 opencensus==0.1.7
+protobuf==3.7.0


### PR DESCRIPTION
- [x] fix  examples/opencensus/python-app not work by google.protobuf.internal.well_known_types.ParseError #37 